### PR TITLE
add last_pose to motion_data

### DIFF
--- a/include/frankx/motion_impedance_generator.hpp
+++ b/include/frankx/motion_impedance_generator.hpp
@@ -60,6 +60,14 @@ struct ImpedanceMotionGenerator: public MotionGenerator {
             init(robot_state, period);
         }
 
+        if(data.last_pose_lock) {
+            const std::lock_guard<std::mutex> lock(*(data.last_pose_lock));
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+        else {
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+
         std::array<double, 7> coriolis_array = model->coriolis(robot_state);
         std::array<double, 42> jacobian_array = model->zeroJacobian(franka::Frame::kEndEffector, robot_state);
 

--- a/include/frankx/motion_joint_generator.hpp
+++ b/include/frankx/motion_joint_generator.hpp
@@ -50,6 +50,14 @@ struct JointMotionGenerator: public MotionGenerator {
             init(robot_state, period);
         }
 
+        if(data.last_pose_lock) {
+            const std::lock_guard<std::mutex> lock(*(data.last_pose_lock));
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+        else {
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+
 #ifdef WITH_PYTHON
         if (robot->stop_at_python_signal && Py_IsInitialized() && PyErr_CheckSignals() == -1) {
             robot->stop();

--- a/include/frankx/motion_path_generator.hpp
+++ b/include/frankx/motion_path_generator.hpp
@@ -50,6 +50,14 @@ struct PathMotionGenerator: public MotionGenerator {
     franka::CartesianPose operator()(const franka::RobotState& robot_state, franka::Duration period) {
         time += period.toSec();
 
+        if(data.last_pose_lock) {
+            const std::lock_guard<std::mutex> lock(*(data.last_pose_lock));
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+        else {
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+
 #ifdef WITH_PYTHON
         if (robot->stop_at_python_signal && Py_IsInitialized() && PyErr_CheckSignals() == -1) {
             robot->stop();

--- a/include/frankx/motion_waypoint_generator.hpp
+++ b/include/frankx/motion_waypoint_generator.hpp
@@ -83,6 +83,14 @@ struct WaypointMotionGenerator: public MotionGenerator {
             init(robot_state, period);
         }
 
+        if(data.last_pose_lock) {
+            const std::lock_guard<std::mutex> lock(*(data.last_pose_lock));
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+        else {
+            data.last_pose = Affine(robot_state.O_T_EE);
+        }
+
         for (auto& reaction : data.reactions) {
             if (reaction.has_fired) {
                 continue;

--- a/include/movex/robot/motion_data.hpp
+++ b/include/movex/robot/motion_data.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
 #include <movex/robot/reaction.hpp>
+#include <movex/affine.hpp>
 
+#include <mutex>
 
 namespace movex {
 
-struct MotionData {    
+struct MotionData {
     double velocity_rel {1.0}, acceleration_rel {1.0}, jerk_rel {1.0};
     bool max_dynamics {false};
 
     std::vector<Reaction> reactions {};
+    std::shared_ptr<std::mutex> last_pose_lock {nullptr};
+    Affine last_pose {};
 
     explicit MotionData(double dynamic_rel = 1.0): velocity_rel(dynamic_rel), acceleration_rel(dynamic_rel), jerk_rel(dynamic_rel) { }
 


### PR DESCRIPTION
I want to read the current pose while the robot is moving in another thread.
So I added last_pose (Affine) to MotionData. The variable is written in the motion-generator function.
I added the variable last_pose_lock (shared_ptr<mutex>) to provide thread safety. 
There have to be probably some adaptions for python.
