### PR TITLE
add currentJointPositions Function to Robot

### DIFF
--- a/include/frankx/robot.hpp
+++ b/include/frankx/robot.hpp
@@ -76,6 +76,7 @@ public:
     bool recoverFromErrors();
 
     Affine currentPose(const Affine& frame = Affine());
+    std::array<double, 7> currentJointPositions();
     Affine forwardKinematics(const std::array<double, 7>& q);
     std::array<double, 7> inverseKinematics(const Affine& target, const std::array<double, 7>& q0);
 

--- a/src/frankx/robot.cpp
+++ b/src/frankx/robot.cpp
@@ -45,6 +45,11 @@ Affine Robot::currentPose(const Affine& frame) {
     return Affine(state.O_T_EE) * frame;
 }
 
+std::array<double, 7> Robot::currentJointPositions() {
+    auto state = readOnce();
+    return state.q;
+}
+
 Affine Robot::forwardKinematics(const std::array<double, 7>& q) {
     const Eigen::Matrix<double, 7, 1> q_current = Eigen::Map<const Eigen::Matrix<double, 7, 1>>(q.data(), q.size());
     return Affine(Kinematics::forward(q_current));


### PR DESCRIPTION
I want to readout the current joint states when the robot is not moving, like I can do with the  Pose. This PR adds a function currentJointPositions to Robot.