### PR TITLE
update feature in python API: get robot state & gripper state

### DIFF
--- a/include/frankx/gripper.hpp
+++ b/include/frankx/gripper.hpp
@@ -46,6 +46,9 @@ public:
     bool release();
     bool release(double width); // [m]
     bool releaseRelative(double width); // [m]
+    
+    
+    ::franka::GripperState get_state();
 };
 
 } // namepace frankx

--- a/include/frankx/robot.hpp
+++ b/include/frankx/robot.hpp
@@ -81,6 +81,8 @@ public:
     std::array<double, 7> currentJointPositions();
     Affine forwardKinematics(const std::array<double, 7>& q);
     std::array<double, 7> inverseKinematics(const Affine& target, const std::array<double, 7>& q0);
+    
+    ::franka::RobotState get_state();
 
     bool move(ImpedanceMotion& motion);
     bool move(ImpedanceMotion& motion, MotionData& data);

--- a/src/frankx/gripper.cpp
+++ b/src/frankx/gripper.cpp
@@ -85,4 +85,8 @@ bool Gripper::releaseRelative(double width_relative) { // [m]
   return release(width() + width_relative);
 }
 
+::franka::GripperState Gripper::get_state() {
+    return readOnce();
+}
+
 } // namepace frankx

--- a/src/frankx/python.cpp
+++ b/src/frankx/python.cpp
@@ -293,6 +293,7 @@ PYBIND11_MODULE(_frankx, m) {
         .def("current_pose", &Robot::currentPose, "frame"_a = Affine())
         .def("forward_kinematics", &Robot::forwardKinematics, "q"_a)
         .def("inverse_kinematics", &Robot::inverseKinematics, "target"_a, "q0"_a)
+        .def("get_state", &Robot::get_state)
         .def("move", (bool (Robot::*)(ImpedanceMotion&)) &Robot::move, py::call_guard<py::gil_scoped_release>())
         .def("move", (bool (Robot::*)(ImpedanceMotion&, MotionData&)) &Robot::move, py::call_guard<py::gil_scoped_release>())
         .def("move", (bool (Robot::*)(const Affine&, ImpedanceMotion&)) &Robot::move, py::call_guard<py::gil_scoped_release>())
@@ -336,7 +337,8 @@ PYBIND11_MODULE(_frankx, m) {
         .def("clamp", (bool (Gripper::*)(double)) &Gripper::clamp, py::call_guard<py::gil_scoped_release>())
         .def("release", (bool (Gripper::*)()) &Gripper::release, py::call_guard<py::gil_scoped_release>())
         .def("release", (bool (Gripper::*)(double)) &Gripper::release, py::call_guard<py::gil_scoped_release>())
-        .def("releaseRelative", &Gripper::releaseRelative, py::call_guard<py::gil_scoped_release>());
+        .def("releaseRelative", &Gripper::releaseRelative, py::call_guard<py::gil_scoped_release>())
+        .def("get_state", &Gripper::get_state);
 
     py::register_exception<franka::CommandException>(m, "CommandException");
     py::register_exception<franka::ControlException>(m, "ControlException");

--- a/src/frankx/robot.cpp
+++ b/src/frankx/robot.cpp
@@ -74,6 +74,10 @@ std::array<double, 7> Robot::inverseKinematics(const Affine& target, const std::
     return result;
 }
 
+::franka::RobotState Robot::get_state() {
+    return readOnce();
+}
+
 bool Robot::move(ImpedanceMotion& motion) {
     return move(Affine(), motion);
 }


### PR DESCRIPTION
Hi, @pantor

I observe that current python APIs have no support for state fetching for both robot & gripper, though the python binding code has defined `GripperState` and `RobotState`.

To fix this issue, I suggest that we can use a member function inside class `Robot` and `Gripper` to fetch their state using `readOnce()` provided in libfranka. Specifically, I implement a simple `get_state()` function inside both classes.

The code has been tested under the machine, here are the example usage.

```python
from frankx import Robot

# Initialize
robot = Robot('172.16.0.2')
gripper = robot.get_gripper()

# Get the robot state and gripper state, and print some of them on the screen
robot_state = robot.get_state()
gripper_state = gripper.get_state()
print(robot_state.O_T_EE)
print(gripper_state.width)
```