### PR TITLE
Non RT kernel support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 
 
 if(BUILD_EXAMPLES)
-  foreach(example IN ITEMS linear grasping)
+  foreach(example IN ITEMS linear grasping linear_non_rt)
     add_executable(${example} "examples/${example}.cpp")
     target_link_libraries(${example} PRIVATE frankx)
   endforeach()

--- a/examples/linear_non_rt.cpp
+++ b/examples/linear_non_rt.cpp
@@ -1,0 +1,30 @@
+#include <frankx/frankx.hpp>
+
+
+using namespace frankx;
+
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        std::cerr << "Usage: " << argv[0] << " <robot-hostname>" << std::endl;
+        return -1;
+    }
+
+    // Connect to the robot
+    Robot robot(argv[1], 0.1, true, true, franka::RealtimeConfig::kIgnore);
+    robot.automaticErrorRecovery();
+
+    // Reduce the acceleration and velocity dynamic
+    robot.setDynamicRel(0.15);
+
+    // Define and move forwards
+    auto way = Affine(0.0, 0.2, 0.0);
+    auto motion_forward = LinearRelativeMotion(way);
+    robot.move(motion_forward);
+
+    // And move backwards using the inverse motion
+    auto motion_backward = LinearRelativeMotion(way.inverse());
+    robot.move(motion_backward);
+
+    return 0;
+}

--- a/examples/linear_non_rt.py
+++ b/examples/linear_non_rt.py
@@ -1,0 +1,26 @@
+from argparse import ArgumentParser
+
+from frankx import Affine, LinearRelativeMotion, Robot, RealtimeConfig
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--host', default='172.16.0.2', help='FCI IP of the robot')
+    args = parser.parse_args()
+
+    # Connect to the robot
+    robot = Robot(args.host, realtime_config=RealtimeConfig.Ignore)
+    robot.set_default_behavior()
+    robot.recover_from_errors()
+
+    # Reduce the acceleration and velocity dynamic
+    robot.set_dynamic_rel(0.15)
+
+    # Define and move forwards
+    way = Affine(0.0, 0.2, 0.0)
+    motion_forward = LinearRelativeMotion(way)
+    robot.move(motion_forward)
+
+    # And move backwards using the inverse motion
+    motion_backward = LinearRelativeMotion(way.inverse())
+    robot.move(motion_backward)

--- a/frankx/__init__.py
+++ b/frankx/__init__.py
@@ -20,6 +20,7 @@ from _frankx import (
     StopMotion,
     Waypoint,
     WaypointMotion,
+    RealtimeConfig,
 )
 
 from .gripper import Gripper

--- a/frankx/robot.py
+++ b/frankx/robot.py
@@ -1,4 +1,5 @@
 import base64
+import imp
 import json
 import hashlib
 from http.client import HTTPSConnection
@@ -7,12 +8,13 @@ from time import sleep
 from threading import Thread
 
 from _frankx import Robot as _Robot
+from _frankx import RealtimeConfig as _RealtimeConfig
 from .gripper import Gripper as _Gripper
 
 
 class Robot(_Robot):
-    def __init__(self, fci_ip, dynamic_rel=1.0, user=None, password=None, repeat_on_error=True, stop_at_python_signal=True):
-        super().__init__(fci_ip, dynamic_rel=dynamic_rel, repeat_on_error=repeat_on_error, stop_at_python_signal=stop_at_python_signal)
+    def __init__(self, fci_ip, dynamic_rel=1.0, user=None, password=None, repeat_on_error=True, stop_at_python_signal=True, realtime_config=_RealtimeConfig.Enforce):
+        super().__init__(fci_ip, dynamic_rel=dynamic_rel, repeat_on_error=repeat_on_error, stop_at_python_signal=stop_at_python_signal, realtime_config=realtime_config)
         self.hostname = fci_ip
         self.user = user
         self.password = password

--- a/include/frankx/robot.hpp
+++ b/include/frankx/robot.hpp
@@ -69,7 +69,7 @@ public:
     bool stop_at_python_signal {true};
 
     //! Connects to a robot at the given FCI IP address.
-    explicit Robot(std::string fci_ip, double dynamic_rel = 1.0, bool repeat_on_error = true, bool stop_at_python_signal = true);
+    explicit Robot(std::string fci_ip, double dynamic_rel = 1.0, bool repeat_on_error = true, bool stop_at_python_signal = true, franka::RealtimeConfig realtime_config = franka::RealtimeConfig::kEnforce);
 
     void setDefaultBehavior();
     void setDynamicRel(double dynamic_rel);

--- a/src/frankx/python.cpp
+++ b/src/frankx/python.cpp
@@ -214,6 +214,11 @@ PYBIND11_MODULE(_frankx, m) {
         .value("CartesianImpedance", franka::ControllerMode::kCartesianImpedance)
         .export_values();
 
+    py::enum_<franka::RealtimeConfig>(m, "RealtimeConfig")
+        .value("Enforce", franka::RealtimeConfig::kEnforce)
+        .value("Ignore", franka::RealtimeConfig::kIgnore)
+        .export_values();
+
     py::class_<franka::RobotState>(m, "RobotState")
         .def_readonly("O_T_EE", &franka::RobotState::O_T_EE)
         .def_readonly("O_T_EE_d", &franka::RobotState::O_T_EE_d)
@@ -260,7 +265,7 @@ PYBIND11_MODULE(_frankx, m) {
         .def_readonly("time", &franka::RobotState::time);
 
     py::class_<Robot>(m, "Robot")
-        .def(py::init<const std::string &, double, bool, bool>(), "fci_ip"_a, "dynamic_rel"_a = 1.0, "repeat_on_error"_a = true, "stop_at_python_signal"_a = true)
+        .def(py::init<const std::string &, double, bool, bool, franka::RealtimeConfig &>(), "fci_ip"_a, "dynamic_rel"_a = 1.0, "repeat_on_error"_a = true, "stop_at_python_signal"_a = true, "realtime_config"_a = franka::RealtimeConfig::kEnforce)
         .def_readonly_static("max_translation_velocity", &Robot::max_translation_velocity)
         .def_readonly_static("max_rotation_velocity", &Robot::max_rotation_velocity)
         .def_readonly_static("max_elbow_velocity", &Robot::max_elbow_velocity)

--- a/src/frankx/robot.cpp
+++ b/src/frankx/robot.cpp
@@ -5,7 +5,7 @@
 
 namespace frankx {
 
-Robot::Robot(std::string fci_ip, double dynamic_rel, bool repeat_on_error, bool stop_at_python_signal): franka::Robot(fci_ip), fci_ip(fci_ip), velocity_rel(dynamic_rel), acceleration_rel(dynamic_rel), jerk_rel(dynamic_rel), repeat_on_error(repeat_on_error), stop_at_python_signal(stop_at_python_signal) { }
+Robot::Robot(std::string fci_ip, double dynamic_rel, bool repeat_on_error, bool stop_at_python_signal, franka::RealtimeConfig realtime_config): franka::Robot(fci_ip,realtime_config), fci_ip(fci_ip), velocity_rel(dynamic_rel), acceleration_rel(dynamic_rel), jerk_rel(dynamic_rel), repeat_on_error(repeat_on_error), stop_at_python_signal(stop_at_python_signal) { }
 
 void Robot::setDefaultBehavior() {
     setCollisionBehavior(


### PR DESCRIPTION
Hi. First of all, thank you for this amazing library. This PR is to add support to use the robot with a non real-time kernel. 
This is optional and it can be selected at run time. I added two examples to show how to use it. 
It can be useful to use the robot with a PC where NVIDIA drivers are installed. I currently tested the code with libfranka 0.8.0 