### PR TITLE
add Waypoint constructor with blend and velocity

### DIFF
--- a/include/movex/waypoint.hpp
+++ b/include/movex/waypoint.hpp
@@ -51,7 +51,7 @@ struct Waypoint {
 
     // explicit Waypoint(const Affine& affine, double blend_max_distance): affine(affine), blend_max_distance(blend_max_distance) {}
     explicit Waypoint(const Affine& affine, std::optional<double> elbow, double blend_max_distance): affine(affine), elbow(elbow), blend_max_distance(blend_max_distance), reference_type(ReferenceType::Absolute) {}
-
+    explicit Waypoint(const Affine& affine, double velocity_rel, double blend_max_distance, std::optional<double> elbow): affine(affine), velocity_rel(velocity_rel), blend_max_distance(blend_max_distance), elbow(elbow), reference_type(ReferenceType::Absolute) {}
 
     Affine getTargetAffine(const Affine& frame, const Affine& old_affine) const {
         switch (reference_type) {

--- a/src/frankx/python.cpp
+++ b/src/frankx/python.cpp
@@ -72,6 +72,7 @@ PYBIND11_MODULE(_frankx, m) {
         .def(py::init<double>(), "minimum_time"_a)
         .def(py::init<const Affine &, ReferenceType, double>(), "affine"_a, "reference_type"_a = ReferenceType::Absolute, "dynamic_rel"_a = 1.0)
         .def(py::init<const Affine &, double, ReferenceType, double>(), "affine"_a, "elbow"_a, "reference_type"_a = ReferenceType::Absolute, "dynamic_rel"_a = 1.0)
+        .def(py::init<const Affine &, double, double, std::optional<double>>(), "affine"_a, "velocity_rel"_a, "blend_max_distance"_a, "elbow"_a = std::nullopt)
         .def_readwrite("velocity_rel", &Waypoint::velocity_rel)
         .def_readonly("affine", &Waypoint::affine)
         .def_readonly("elbow", &Waypoint::elbow)


### PR DESCRIPTION
Closes #42 
Adds an additional constructor to define velocity, blend distance, and elbow parameters to waypoints.
This has been tested with a Franka Emika Panda.